### PR TITLE
Newlines in text getting pushed

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,9 +1,7 @@
 build:
-    nodes:
-        psonic:
-            tests:
-                override:
-                    - command: phpunit --filter "no tests in scrutinizer"
+    tests:
+        override:
+            command: phpunit --filter "no tests in scrutinizer"
 
 filter:
     excluded_paths: [tests/*]

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,3 +1,10 @@
+build:
+    nodes:
+        psonic:
+            tests:
+                override:
+                    - command: phpunit --filter "no tests in scrutinizer"
+
 filter:
     excluded_paths: [tests/*]
 

--- a/src/Commands/Command.php
+++ b/src/Commands/Command.php
@@ -16,11 +16,13 @@ abstract class Command implements CommandInterface
     }
 
     /**
-     * Wrap the string in quotes, and escape any double quotes that are already in the string
+     * Wrap the string in quotes, and normalize whitespace. Also remove double quotes.
      */
     protected function wrapInQuotes($string)
     {
-        return '"' . str_replace('"', '\"', $string) . '"';
+        $string = preg_replace('/[\r\n\t"]/', ' ', $string);
+        $string = '"' . str_replace('"', '\"', $string) . '"';
+        return $string;
     }
 
     public function __toString(): string

--- a/src/Commands/Search/SuggestCommand.php
+++ b/src/Commands/Search/SuggestCommand.php
@@ -16,14 +16,13 @@ final class SuggestCommand extends Command
      * @param string $terms
      * @param null $limit
      */
-    public function __construct(string $collection, string $bucket, string $terms, $limit = null, $locale=null)
+    public function __construct(string $collection, string $bucket, string $terms, $limit = null)
     {
         $this->parameters = [
             'collection' => $collection,
             'bucket'     => $bucket,
             'terms'      => self::wrapInQuotes($terms),
             'limit'      => $limit ? "LIMIT($limit)" : null,
-            'locale'      => $locale ? "LIMIT($locale)" : null,
         ];
 
         parent::__construct($this->command, $this->parameters);

--- a/tests/Unit/IngestChannelTest.php
+++ b/tests/Unit/IngestChannelTest.php
@@ -29,6 +29,7 @@ class IngestChannelTest extends TestCase
         $this->assertEquals("OK", $this->ingest->push($this->collection, $this->bucket, "4567", "hi Naveen")->getStatus());
         $this->assertEquals("OK", $this->ingest->push($this->collection, $this->bucket, "7890", "hi Jomit")->getStatus());
         $this->assertEquals("OK", $this->ingest->push($this->collection, $this->bucket, "1122", 'hi "quoted" text')->getStatus());
+        $this->assertEquals("OK", $this->ingest->push($this->collection, $this->bucket, "1133", "Newlines\nshould\nbe\nnormalized\nto\nspaces")->getStatus());
     }
 
     /**


### PR DESCRIPTION
If there are newlines in the text that gets wrapped in quotes it needs to be normalized.

Otherwise the newline is the end of the command, which would be premature, and the quote isn't fully wrapped in double quotes!